### PR TITLE
Add admin_only_view and doctor_or_admin_view filters

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -1,5 +1,6 @@
 class AdminsController < ApplicationController
   before_action :set_admin, only: [:show, :edit, :update, :destroy]
+  before_filter :authenticate_user! # redirect if user isn't signed in
 
   # GET /admins
   # GET /admins.json

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,19 +20,15 @@ class ApplicationController < ActionController::Base
   # Use this view if you want to restrict 
   def admin_only_view
     if !current_user.is_a? Admin
-      redirect_to 'http://google.com' # Replace this with a redirect to a 403 page
-      # Or just to root with a flash ntoice telling them the action is available only
-      # to certain users.
+      render html: "<h1>403 - Not Authorized</h1".html_safe
     end
   end
 
   # Use this view if you want to ensure that a particular action is available
   # only to people who have been explicitly whitelisted by an admin.
   def doctor_or_admin_view
-    if !(current_user.is_a? Doctor || current_user.is_a? Admin)
-      redirect_to 'http://google.com' # Replace this with a redirect to a 403 page, 
-      # Or just to root with a flash notice telling them the action is available only
-      # to certain users.
+    if !((current_user.is_a? Doctor) || (current_user.is_a? Admin))
+      render html: "<h1>403 - Not Authorized</h1".html_safe
     end
   end 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,4 +16,23 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.for(:account_update) << [:first_name, :last_name]
   end
+
+  # Use this view if you want to restrict 
+  def admin_only_view
+    if !current_user.is_a? Admin
+      redirect_to 'http://google.com' # Replace this with a redirect to a 403 page
+      # Or just to root with a flash ntoice telling them the action is available only
+      # to certain users.
+    end
+  end
+
+  # Use this view if you want to ensure that a particular action is available
+  # only to people who have been explicitly whitelisted by an admin.
+  def doctor_or_admin_view
+    if !(current_user.is_a? Doctor || current_user.is_a? Admin)
+      redirect_to 'http://google.com' # Replace this with a redirect to a 403 page, 
+      # Or just to root with a flash notice telling them the action is available only
+      # to certain users.
+    end
+  end 
 end

--- a/app/controllers/doctors_controller.rb
+++ b/app/controllers/doctors_controller.rb
@@ -1,5 +1,6 @@
 class DoctorsController < ApplicationController
   before_action :set_doctor, only: [:show, :edit, :update, :destroy]
+  before_filter :authenticate_user! # Redirects if user isn't signed in
 
   # GET /doctors
   # GET /doctors.json

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,77 @@
+class UsersController < ApplicationController
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
+  before_action :admin_only_filter, only: [:edit]
+  # GET /users
+  # GET /users.json
+  def index
+    @users = User.all
+  end
+
+  # GET /users/1
+  # GET /users/1.json
+  def show
+  end
+
+  # GET /users/1/edit
+  def edit
+  end
+
+  # POST /users
+  # POST /users.json
+  def create
+    @user = User.new(user_params)
+
+    respond_to do |format|
+      if @user.save
+        format.html { redirect_to @user, notice: 'User was successfully created.' }
+        format.json { render :show, status: :created, location: @user }
+      else
+        format.html { render :new }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /users/1
+  # PATCH/PUT /users/1.json
+  def update
+    respond_to do |format|
+      if @user.update(user_params)
+        format.html { redirect_to @user, notice: 'User was successfully updated.' }
+        format.json { render :show, status: :ok, location: @user }
+      else
+        format.html { render :edit }
+        format.json { render json: @user.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /users/1
+  # DELETE /users/1.json
+  def destroy
+    @user.destroy
+    respond_to do |format|
+      format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_user
+      @user = User.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def user_params
+      params.require(:user).permit(:first_name, :last_name, :email_address, :is_admin)
+    end
+
+    def admin_only_filter
+      if !current_user.is_admin
+        flash[:notice] = "View restricted to admins only"
+        redirect_to users_path
+      end
+    end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,7 @@
 class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
-  before_action :admin_only_filter, only: [:edit]
+  before_filter :authenticate_user! # Redirect unless user is logged in.
+
   # GET /users
   # GET /users.json
   def index
@@ -66,12 +67,4 @@ class UsersController < ApplicationController
     def user_params
       params.require(:user).permit(:first_name, :last_name, :email_address, :is_admin)
     end
-
-    def admin_only_filter
-      if !current_user.is_admin
-        flash[:notice] = "View restricted to admins only"
-        redirect_to users_path
-      end
-    end
-
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,5 +5,4 @@ class User < ActiveRecord::Base
          :recoverable, :rememberable, :trackable, :validatable
 
   attr_accessor :first_name, :last_name
-
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 Rails.application.routes.draw do
   resources :admins, :doctors
 
-
   # We're implementing a custom controller for registration purposes.
   devise_for :users, path_names: {sign_in: 'login', sign_out: 'logout'}, controllers: {registrations: 'users/registrations'}
   namespace :doctors do


### PR DESCRIPTION
I've written to filters to handle the two levels of permissioning we have:

* Doctors can view (which implies that admins can also view this resource, since they are the admin
* Admins only can view.

These filters are creatively named.

Right now they are stupidly and just render HTML inline, but it might be worth breaking this out into a full-blown error controller later.