### PR TITLE
fix jquery to setup email body and adapt controller paramters

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :development, :test do
 
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
-  
+
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'cucumber-rails', :require => false
@@ -64,7 +64,7 @@ group :development, :test do
   gem 'codeclimate-test-reporter', require: nil
   gem 'factory_girl', '~> 2.2'
   gem 'capybara'
-  gem "capybara-webkit"
+  gem 'capybara-webkit'
   gem 'poltergeist'
   gem 'autotest-rails'
 end

--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -27,7 +27,7 @@ class AdminsController < ApplicationController
   # GET /admins/1/edit
   def edit
     @admin = Admin.find(params[:id])
-    
+
   end
 
   def create_email
@@ -37,9 +37,12 @@ class AdminsController < ApplicationController
     @doctors = Doctor.all
     sent_to = "Email sent to: " + Admin.get_doctor_names(@doctors)
     @doctors.each do |doctor|
-      if params.has_key?(:urgent)
+
+      case params[:email_type]
+      when 'urgent'
+        #UserMailer.send
         UserMailer.urgent_email(doctor).deliver_now
-      elsif params.has_key?(:new_pay_period)
+      when 'new_pay_period'
         UserMailer.new_pay_period_email(doctor).deliver_now
       else
         subject = params[:subject]
@@ -47,6 +50,7 @@ class AdminsController < ApplicationController
         UserMailer.custom_email(doctor, subject, text).deliver_now
       end
     end
+    
     flash[:notice] = sent_to
     redirect_to '/'
   end
@@ -101,7 +105,7 @@ class AdminsController < ApplicationController
       flash[:notice] = "Approved #{@user.first_name} as a doctor!"
     end
   end
-  
+
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_admin

--- a/app/views/admins/create_email.html.erb
+++ b/app/views/admins/create_email.html.erb
@@ -1,13 +1,14 @@
 <h1>Create new Email</h1>
 
-<%= form_tag send_email_path do %>
-	<%= check_box_tag :urgent %>
-	<%= label_tag :urgent, "Use urgent email prefill", :id => 'urgent-checkbox' %>
-	<%= check_box_tag :new_pay_period %>
-	<%= label_tag :new_pay_period, "Use new pay period email prefill", :id => 'new-pay-period-checkbox' %>
-	<%= check_box_tag :custom %>
-	<%= label_tag :custom, "Write custom email", :id => 'custom-checkbox' %>
-	
+
+<%= form_tag send_mass_email_path do %>
+	<%= radio_button_tag :email_type, :urgent %>
+	<%= label_tag :urgent, "Use urgent email prefill" %>
+	<%= radio_button_tag :email_type, :new_pay_period %>
+	<%= label_tag :new_pay_period, "Use new pay period email prefill" %>
+	<%= radio_button_tag :email_type, :custom , true%>
+	<%= label_tag :custom, "Write custom email" %>
+
 	<br>
 
   <%= label_tag(:subject, "Subject") %>
@@ -17,7 +18,7 @@
   <%= label_tag(:body, "Email Body") %>
   <br>
   <%= text_area_tag :body, "Email Body", :id => 'email-body', :size => '70x20' %>
-  <br>	
+  <br>
   <%= submit_tag "Send Email" %>
 <% end %>
 
@@ -40,7 +41,7 @@ The Moonlighter Team
 Hey *|first_name|*,
 
 There are still unfulfilled shifts for the *|pay_period_range|* pay perdiod. Feel free to sign up now at here
-		
+
 As a reminder, these shifts do not need to be approved by the Calendar Admin. You may sign yourself up from any shift you would like.
 
 Happy scheduling!
@@ -51,22 +52,24 @@ The Moonlighter Team
 <script>
 	var $email_body = $("#email-body"),
 			$email_subject = $("#email-subject");
+			console.log("script launched")
 
-	$("#urgent-checkbox").on('click', function() {
+	$("#email_type_urgent").on('click', function() {
+			console.log("click !")
 			$email_body.val($('#urgent-text > pre').text())
 			$email_subject.val($('#urgent-text > p').text())
 			$(":checkbox").prop('checked', false);
 			$email_body.attr("disabled",true)
 	});
 
-	$("#new-pay-period-checkbox").on('click', function() {
+	$("#email_type_new_pay_period").on('click', function() {
 			$email_body.val($('#new-pay-period-text > pre').text())
 			$email_subject.val($('#new-pay-period-text > p').text())
 			$(":checkbox").prop('checked', false);
 			$email_body.attr("disabled",true)
 	});
 
-	$("#custom-checkbox").on('click', function() {
+	$("#email_type_custom").on('click', function() {
 			$email_body.val("")
 			$email_subject.val("")
 			$(":checkbox").prop('checked', false);


### PR DESCRIPTION
I changed the jquery part on the create_new_email view. I chose more appropriate id names for the radio button. this ruby code <%= radio_button_tag :email_type, :urgent %> will generate <input type="radio" name="email_type" id="email_type_urgent" value="urgent"> and the jquery is looking for button's ids not labels ids. That was the problem :)