### PR TITLE
Add cronjob to delete completed shifts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ gem 'mandrill-api', require: 'mandrill'
 #using for Google Calendar integration
 gem 'google-api-client'
 
+# Cronjobs made easy.
+gem 'whenever', :require => false
+
 group :production do
  gem 'pg'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -72,4 +72,7 @@ group :development, :test do
   gem 'capybara'
   gem 'poltergeist'
   gem 'autotest-rails'
+
+  # Used for time-dependent RSpec tests
+  gem 'timecop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,6 +248,7 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
+    timecop (0.7.3)
     turbolinks (2.5.3)
       coffee-rails
     tzinfo (1.2.2)
@@ -297,6 +298,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   spring
   sqlite3 (~> 1.3.10)
+  timecop
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chronic (0.10.2)
     cliver (0.3.2)
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
@@ -264,6 +265,8 @@ GEM
     websocket-driver (0.5.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -297,3 +300,4 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  whenever

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -1,6 +1,11 @@
 class Admin < User
 	@@NAME = "Admin"
 	belongs_to :pay_period
+
+  # We only want to read this field, should never be able to update it for admins
+  # The only reason this exists is because we're leveraging STI even though we've 
+  # grown out of it at this point.
+
 	def self.NAME; @@NAME; end
 
 	def self.get_doctor_names(doctors)
@@ -28,4 +33,20 @@ class Admin < User
 			adm.update_attribute(:pay_period_id, id)
 		end
 	end
+
+  # We only want to read this field, should never be able to update it for admins
+  # The only reason this exists is because we're leveraging STI even though we've 
+  # grown out of it at this point. Always return nil here.
+  def last_shift_completion_date
+    return nil
+  end
+
+  # We need to define this method here, or else it will hoist up to the User class
+  # where this method is defined. We throw an exception here so any unsuspecting programmer
+  # attempting to use this method will enconter this error in testing and come here.
+  # Remember -- This construction doesn't make sense for Admins. The only reason it's even
+  # available to admins is because we're using STI, which we're hoping to refactor soon.
+  def last_shift_completion_date= 
+    raise Exception
+  end
 end

--- a/app/models/doctor.rb
+++ b/app/models/doctor.rb
@@ -1,11 +1,20 @@
 class Doctor < User
 	has_many :shifts
+
+  # NOTE: THIS ASSUMES MONTHS! IF YOU CHANGE THIS VALUE, YOU NEED
+  # TO CHANGE THE CALL TO Date#advance IN THE is_delinquent? METHOD
+  MAX_TIME_SINCE_LAST_SHIFT = 2
+
 	@@NAME = "Doctor"
 	def self.NAME; @@NAME; end
 
 	def self.update_pay_period(id)
-		Doctor.all.each do |doc|
-			doc.update_attribute(:pay_period_id, id)
-		end
+		Doctor.update_all(:pay_period_id, id)
 	end
+
+  def is_delinquent?
+    # If last_shift_completion_date is non-nil, then return true if the last_shift
+    # completion date is occurred over MAX_TIME_SINCE_LAST_SHIFT time ago
+    return (self.last_shift_completion_date.advance(months: MAX_TIME_SINCE_LAST_SHIFT) < Date.today) if self.last_shift_completion_date
+  end
 end

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -100,6 +100,28 @@ class Shift < ActiveRecord::Base
     return errors_hash
   end
 
+  def self.delete_completed_shifts
+    # We could just delete these right away, but we need to update the doctors `last_shift_completed` field.
+    # This shouldn't be too expensive becuase there will be a maximum of like 20 shifts to delete at any given
+    # time becuase we're just deleting the shifts from the previous 24 hours.
+
+
+    # We fix this time because we only want to delete shifts for which we've updated the doctors,
+    # and there is (albeit small) possiblity that a shift could have completed while we're running
+    # this query
+    fixed_time = DateTime.now
+    completed_shifts = Shift.where("end_datetime <= ?", fixed_time)
+    completed_shifts.each do |shift|
+      doc = shift.doctor
+      doc.last_shift_completed = shift.end_datetime.to_date #convert to date because it shouldn't matter at the exact time they stopped.
+      doc.save
+    end
+    # Delete all shifts at once so we do less transactions.
+    # NOTE: This does NOT invoke the callbacks nor does it use the destroy method.
+    # This prevents instanation of each object a la destroy_all
+    Shift.where("end_datetime <= ?", fixted ).delete_all 
+  end
+
   private
 
   def self.create_shift_from_hash(data_hash, pay_period_id)

--- a/app/models/shift.rb
+++ b/app/models/shift.rb
@@ -101,7 +101,7 @@ class Shift < ActiveRecord::Base
   end
 
   def self.delete_completed_shifts
-    # We could just delete these right away, but we need to update the doctors `last_shift_completed` field.
+    # We could just delete these right away, but we need to update the doctors `last_shift_completion_date` field.
     # This shouldn't be too expensive becuase there will be a maximum of like 20 shifts to delete at any given
     # time becuase we're just deleting the shifts from the previous 24 hours.
 
@@ -113,13 +113,13 @@ class Shift < ActiveRecord::Base
     completed_shifts = Shift.where("end_datetime <= ?", fixed_time)
     completed_shifts.each do |shift|
       doc = shift.doctor
-      doc.last_shift_completed = shift.end_datetime.to_date #convert to date because it shouldn't matter at the exact time they stopped.
+      doc.last_shift_completion_date = shift.end_datetime.to_date #convert to date because it shouldn't matter at the exact time they stopped.
       doc.save
     end
     # Delete all shifts at once so we do less transactions.
     # NOTE: This does NOT invoke the callbacks nor does it use the destroy method.
     # This prevents instanation of each object a la destroy_all
-    Shift.where("end_datetime <= ?", fixted ).delete_all 
+    Shift.where("end_datetime <= ?", fixed_time).delete_all 
   end
 
   private

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,30 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every 1.day, at: '4:30 am' do
+  # Every day, clean up completed shifts.
+  # For each doctor who completes a shift, this Cronjob will update
+  # their `last_completed_shift` field.
+  runner "Shift.delete_completed_shifts"
+  # We need to figure out how we want to notify the doctors about whether or not
+  # they are in denial.
+
+end

--- a/db/migrate/20150426103349_add_last_shift_completion_date.rb
+++ b/db/migrate/20150426103349_add_last_shift_completion_date.rb
@@ -1,0 +1,5 @@
+class AddLastShiftCompletionDate < ActiveRecord::Migration
+  def change
+    add_column :users, :last_shift_completion_date, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150422203509) do
+ActiveRecord::Schema.define(version: 20150426103349) do
 
   create_table "admins", force: :cascade do |t|
     t.datetime "created_at", null: false
@@ -20,8 +20,9 @@ ActiveRecord::Schema.define(version: 20150422203509) do
 
   create_table "doctors", force: :cascade do |t|
     t.integer  "shift_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.date     "last_shift_completion_date"
   end
 
   create_table "pay_periods", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,9 +20,8 @@ ActiveRecord::Schema.define(version: 20150426103349) do
 
   create_table "doctors", force: :cascade do |t|
     t.integer  "shift_id"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.date     "last_shift_completion_date"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "pay_periods", force: :cascade do |t|
@@ -46,14 +45,14 @@ ActiveRecord::Schema.define(version: 20150426103349) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.datetime "created_at",                          null: false
-    t.datetime "updated_at",                          null: false
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
+    t.datetime "created_at",                              null: false
+    t.datetime "updated_at",                              null: false
+    t.string   "email",                      default: "", null: false
+    t.string   "encrypted_password",         default: "", null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0,  null: false
+    t.integer  "sign_in_count",              default: 0,  null: false
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
     t.string   "current_sign_in_ip"
@@ -66,6 +65,7 @@ ActiveRecord::Schema.define(version: 20150426103349) do
     t.string   "phone_2"
     t.string   "phone_3"
     t.string   "comments"
+    t.date     "last_shift_completion_date"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true

--- a/spec/controllers/doctors_controller_spec.rb
+++ b/spec/controllers/doctors_controller_spec.rb
@@ -79,12 +79,4 @@ RSpec.describe DoctorsController, type: :controller do
       end
     end
   end
-
-  describe '#is_delinquent?' do
-    it 'should return false if a doctor has worked a shift in the past MAX_TIME_SINCE_LAST_SHIFT' do
-      stub_const("Doctor::MAX_TIME_SINCE_LAST_SHIFT", 3)
-      expect(Doctor::MAX_TIME_SINCE_LAST_SHIFT).to eql 3
-      FactoryGirl.create(:doctor, last_shift_completion_date: 4.months.ago.to_date)
-    end
-  end
 end

--- a/spec/controllers/doctors_controller_spec.rb
+++ b/spec/controllers/doctors_controller_spec.rb
@@ -79,4 +79,12 @@ RSpec.describe DoctorsController, type: :controller do
       end
     end
   end
+
+  describe '#is_delinquent?' do
+    it 'should return false if a doctor has worked a shift in the past MAX_TIME_SINCE_LAST_SHIFT' do
+      stub_const("Doctor::MAX_TIME_SINCE_LAST_SHIFT", 3)
+      expect(Doctor::MAX_TIME_SINCE_LAST_SHIFT).to eql 3
+      FactoryGirl.create(:doctor, last_shift_completion_date: 4.months.ago.to_date)
+    end
+  end
 end

--- a/spec/models/admin_spec.rb
+++ b/spec/models/admin_spec.rb
@@ -29,4 +29,16 @@ RSpec.describe Admin, type: :model do
      expect(admin.send_email(doctor,{email_type: "custom", subject: "foo", body: "bar"})).to eql nil
     end
   end
+
+  describe 'last_shift_completion_date field' do
+    it 'should not be writeable' do
+      admin = FactoryGirl.create(:admin)
+      expect {admin.last_shift_completion_date = Date.parse('Fri, 26 Jun 2015')}.to raise_error
+    end
+
+    it 'should be readable, but return nil even if a date is set.' do
+      admin = FactoryGirl.create(:admin)
+      expect(admin.last_shift_completion_date).to eql nil
+    end
+  end
 end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -282,20 +282,40 @@ RSpec.describe Shift, type: :model do
     end
   end
 
-  
-  describe '#is_delinquent?' do
-    it 'should return false if a doctor has worked a shift in the past MAX_TIME_SINCE_LAST_SHIFT' do
+  describe "Shift.delete_completed_shifts" do
+    before do
+      Timecop.freeze(DateTime.new(2015, 4, 1, 12, 0, 0))
       stub_const("Doctor::MAX_TIME_SINCE_LAST_SHIFT", 3)
-      expect(Doctor::MAX_TIME_SINCE_LAST_SHIFT).to eql 3
-      a = FactoryGirl.create(:doctor, last_shift_completion_date: 2.months.ago.to_date)
-      expect(a.is_delinquent?).to eql(false)
     end
 
-    it 'should return true if a doctor has worked a shift in the past MAX_TIME_SINCE_LAST_SHIFT' do
-      stub_const("Doctor::MAX_TIME_SINCE_LAST_SHIFT", 3)
-      expect(Doctor::MAX_TIME_SINCE_LAST_SHIFT).to eql 3
-      a = FactoryGirl.create(:doctor, last_shift_completion_date: 4.months.ago.to_date)
-      expect(a.is_delinquent?).to eql(true)
+    it 'should delete all shifts that have occurred but leave pending shifts untouched' do
+      
+      # These shifts are in the past.
+      doc_to_check = FactoryGirl.create(:doctor, email: "test1@example.com")
+      random_doctor = FactoryGirl.create(:doctor, email: "test2@example.com")
+      FactoryGirl.create(:shift, start_datetime: DateTime.now.advance(days: -1), end_datetime: DateTime.now.advance(days: -1, hours: 3), doctor: doc_to_check)
+      FactoryGirl.create(:shift, start_datetime: DateTime.now.advance(days: -3), end_datetime: DateTime.now.advance(days: -3, hours: 3), doctor: random_doctor)
+      FactoryGirl.create(:shift, start_datetime: DateTime.now.advance(days: -5), end_datetime: DateTime.now.advance(days: -5, hours: 3), doctor: random_doctor)
+      # This shift is in the future
+      FactoryGirl.create(:shift, start_datetime: DateTime.now.advance(days: 1), end_datetime: DateTime.now.advance(days: 1, hours: 3), doctor: random_doctor)
+      expect(Shift.all.length).to eql(4)
+      Shift.delete_completed_shifts
+      expect(Shift.all.length).to eql(1)
+      expect(Doctor.find_by_id(doc_to_check.id).last_shift_completion_date).to eql(DateTime.now.advance(days: -1, hours: 3).to_date)
+    end
+
+    it 'should leave shifts that are in progress intact.' do 
+      random_doctor = FactoryGirl.create(:doctor, email: "test1@example.com") 
+      # These shifts are in the past.
+      FactoryGirl.create(:shift, start_datetime: DateTime.now.advance(days: -1), end_datetime: DateTime.now.advance(days: -1, hours: 3), doctor: random_doctor)
+      FactoryGirl.create(:shift, start_datetime: DateTime.now.advance(days: -3), end_datetime: DateTime.now.advance(days: -3, hours: 3), doctor: random_doctor)
+      FactoryGirl.create(:shift, start_datetime: DateTime.now.advance(days: -5), end_datetime: DateTime.now.advance(days: -5, hours: 3), doctor: random_doctor)
+    
+      # This shift is in progress.
+      a = FactoryGirl.create(:shift, start_datetime: DateTime.now.advance(hours: -2), end_datetime: DateTime.now.advance(hours: 1), doctor: random_doctor)
+      expect(Shift.all.length).to eql(4)
+      Shift.delete_completed_shifts
+      expect(Shift.all.length).to eql(1)
     end
   end
 end

--- a/spec/models/shift_spec.rb
+++ b/spec/models/shift_spec.rb
@@ -281,4 +281,21 @@ RSpec.describe Shift, type: :model do
       expect(data).to eql(expected)
     end
   end
+
+  
+  describe '#is_delinquent?' do
+    it 'should return false if a doctor has worked a shift in the past MAX_TIME_SINCE_LAST_SHIFT' do
+      stub_const("Doctor::MAX_TIME_SINCE_LAST_SHIFT", 3)
+      expect(Doctor::MAX_TIME_SINCE_LAST_SHIFT).to eql 3
+      a = FactoryGirl.create(:doctor, last_shift_completion_date: 2.months.ago.to_date)
+      expect(a.is_delinquent?).to eql(false)
+    end
+
+    it 'should return true if a doctor has worked a shift in the past MAX_TIME_SINCE_LAST_SHIFT' do
+      stub_const("Doctor::MAX_TIME_SINCE_LAST_SHIFT", 3)
+      expect(Doctor::MAX_TIME_SINCE_LAST_SHIFT).to eql 3
+      a = FactoryGirl.create(:doctor, last_shift_completion_date: 4.months.ago.to_date)
+      expect(a.is_delinquent?).to eql(true)
+    end
+  end
 end


### PR DESCRIPTION
Deleting these shifts updates the `last_shift_completion_date` attribute on Doctor, which allows us to determine whether or not a Doctor is delinquent or not. This help us notify doctors and admins later.